### PR TITLE
Modify default behavior

### DIFF
--- a/object/file.go
+++ b/object/file.go
@@ -41,16 +41,6 @@ func (d *filestore) path(key string) string {
 
 func (d *filestore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	p := d.path(key)
-	fi, err := os.Stat(p)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if fi.IsDir() {
-		return ioutil.NopCloser(new(bytes.Buffer)), nil
-	}
-
 	f, err := os.Open(p)
 	if err != nil {
 		return nil, err
@@ -75,7 +65,7 @@ func (d *filestore) Get(key string, off, limit int64) (io.ReadCloser, error) {
 func (d *filestore) Put(key string, in io.Reader) error {
 	p := d.path(key)
 
-	if key[len(key)-1:] == dirSuffix {
+	if strings.HasSuffix(key, dirSuffix) {
 		return os.MkdirAll(p, os.FileMode(0700))
 	}
 

--- a/sync.go
+++ b/sync.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,6 +21,7 @@ const (
 	maxResults      = 10240
 	defaultPartSize = 5 << 20
 	maxBlock        = defaultPartSize * 2
+	markDelete      = -1
 )
 
 var (
@@ -50,9 +50,6 @@ func Iterate(store object.ObjectStorage, marker, end string) (<-chan *object.Obj
 		for len(objs) > 0 {
 			for _, obj := range objs {
 				key := obj.Key
-				if obj.Size == 0 || strings.HasSuffix(key, "/") {
-					continue
-				}
 				if key <= lastkey {
 					logger.Fatalf("The keys are out of order: %q >= %q", lastkey, key)
 				}
@@ -239,33 +236,40 @@ func doSync(src, dst object.ObjectStorage, srckeys, dstkeys <-chan *object.Objec
 				}
 				start := time.Now()
 				var err error
-				if obj.Size <= 0 {
-					if !*dry {
-						err = try(2, func() error {
-							if *deleteSrc && obj.Size == 0 {
-								return src.Delete(obj.Key)
-							} else if *deleteDst && obj.Size == -1 {
-								return dst.Delete(obj.Key)
-							} else {
-								return nil
-							}
-						})
-						if *deleteSrc {
-							logger.Debugf("Delete %s from %s", obj.Key, src)
-						} else if *deleteDst {
-							logger.Debugf("Delete %s from %s", obj.Key, dst)
+				if obj.Size == markDelete {
+					if *deleteSrc {
+						if *dry {
+							logger.Debugf("Will delete %s from %s", obj.Key, src)
+							continue
+						}
+						if err = src.Delete(obj.Key); err == nil {
+							logger.Debugf("Deleted %s from %s", obj.Key, src)
+							atomic.AddUint64(&deleted, 1)
+						} else {
+							logger.Errorf("Failed to delete %s from %s: %s", obj.Key, src, err.Error())
+							atomic.AddUint64(&failed, 1)
 						}
 					}
-					if err == nil {
-						atomic.AddUint64(&deleted, 1)
-					} else {
-						atomic.AddUint64(&failed, 1)
+					if *deleteDst {
+						if *dry {
+							logger.Debugf("Will delete %s from %s", obj.Key, dst)
+							continue
+						}
+						if err = dst.Delete(obj.Key); err == nil {
+							logger.Debugf("Deleted %s from %s", obj.Key, dst)
+							atomic.AddUint64(&deleted, 1)
+						} else {
+							logger.Errorf("Failed to delete %s from %s: %s", obj.Key, dst, err.Error())
+							atomic.AddUint64(&failed, 1)
+						}
 					}
 					continue
 				}
-				if !*dry {
-					err = copyInParallel(src, dst, obj)
+				if *dry {
+					logger.Debugf("Will copy %s (%d bytes)", obj.Key, obj.Size)
+					continue
 				}
+				err = copyInParallel(src, dst, obj)
 				if err != nil {
 					atomic.AddUint64(&failed, 1)
 					logger.Errorf("Failed to copy %s: %s", obj.Key, err.Error())
@@ -291,7 +295,7 @@ OUT:
 		for hasMore && (dstobj == nil || obj.Key > dstobj.Key) {
 			var ok bool
 			if *deleteDst && dstobj != nil && dstobj.Key < obj.Key {
-				dstobj.Size = -1
+				dstobj.Size = markDelete
 				todo <- dstobj
 			}
 			dstobj, ok = <-dstkeys
@@ -309,7 +313,7 @@ OUT:
 			todo <- obj
 			atomic.AddUint64(&missing, 1)
 		} else if *deleteSrc && dstobj != nil && obj.Key == dstobj.Key && obj.Size == dstobj.Size {
-			obj.Size = 0
+			obj.Size = markDelete
 			todo <- obj
 		}
 		if dstobj != nil && dstobj.Key == obj.Key {
@@ -318,12 +322,12 @@ OUT:
 	}
 	if *deleteDst && hasMore {
 		if dstobj != nil {
-			dstobj.Size = -1
+			dstobj.Size = markDelete
 			todo <- dstobj
 		}
 		for obj := range dstkeys {
 			if obj != nil {
-				obj.Size = -1
+				obj.Size = markDelete
 				todo <- obj
 			}
 		}

--- a/sync.go
+++ b/sync.go
@@ -50,8 +50,7 @@ func Iterate(store object.ObjectStorage, marker, end string) (<-chan *object.Obj
 		for len(objs) > 0 {
 			for _, obj := range objs {
 				key := obj.Key
-				if obj.Size == 0 && (strings.HasSuffix(key, "/") || strings.HasSuffix(key, "$")) {
-					logger.Debugf("skip directory marker: %s", key)
+				if obj.Size == 0 || strings.HasSuffix(key, "/") {
 					continue
 				}
 				if key <= lastkey {

--- a/sync.go
+++ b/sync.go
@@ -242,7 +242,9 @@ func doSync(src, dst object.ObjectStorage, srckeys, dstkeys <-chan *object.Objec
 							logger.Debugf("Will delete %s from %s", obj.Key, src)
 							continue
 						}
-						if err = src.Delete(obj.Key); err == nil {
+						if err = try(3, func() error {
+							return src.Delete(obj.Key)
+						}); err == nil {
 							logger.Debugf("Deleted %s from %s", obj.Key, src)
 							atomic.AddUint64(&deleted, 1)
 						} else {
@@ -255,7 +257,9 @@ func doSync(src, dst object.ObjectStorage, srckeys, dstkeys <-chan *object.Objec
 							logger.Debugf("Will delete %s from %s", obj.Key, dst)
 							continue
 						}
-						if err = dst.Delete(obj.Key); err == nil {
+						if err = try(3, func() error {
+							return dst.Delete(obj.Key)
+						}); err == nil {
 							logger.Debugf("Deleted %s from %s", obj.Key, dst)
 							atomic.AddUint64(&deleted, 1)
 						} else {


### PR DESCRIPTION
* all objects will be synced as it is (including `/` ending and zero bytes)
* objects ending with `/` will be synced as directories to file system
* directories in file system are not mapped to objects (same as before)

Fix #27 