### PR TITLE
fix single object sync

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -86,6 +86,12 @@ func iterate(store object.ObjectStorage, marker, end string) (<-chan *object.Obj
 				out <- obj
 				first = false
 			}
+			// Corner case: the func parameter `marker` is an empty string("") and exactly
+			// one object which key is an empty string("") returned by the List() method.
+			if lastkey == "" {
+				break END
+			}
+
 			marker = lastkey
 			start = time.Now()
 			logger.Debugf("Continue listing objects from %s marker %q", store, marker)


### PR DESCRIPTION
Currently the case like:
`juicesync [--end=zzz] xxx://xxx.xxx.xxx/abc yyy://yyy.yyy.yyy/abc`

would result in error 
`<FATAL>: The keys are out of order: marker "", last "" current ""`
if exact one object with key `/abc` match the `/abc` prefix.