### PR TITLE
objects range to be synced include start and end

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v11.1.1-beta+incompatible
 	github.com/Azure/go-autorest v8.4.0+incompatible // indirect
 	github.com/NetEase-Object-Storage/nos-golang-sdk v0.0.0-20171031020902-cc8892cb2b05
-	github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20170925032315-6fe16293d6b7
+	github.com/aliyun/aliyun-oss-go-sdk v2.1.0+incompatible
 	github.com/aws/aws-sdk-go v1.12.10
 	github.com/baidubce/bce-sdk-go v0.0.0-20180401121131-aa0c7bd66b01
 	github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Azure/go-autorest v8.4.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWA
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NetEase-Object-Storage/nos-golang-sdk v0.0.0-20171031020902-cc8892cb2b05 h1:NEPjpPSOSDDmnix+VANw/CfUs1fAorLIaz/IFz2eQ2o=
 github.com/NetEase-Object-Storage/nos-golang-sdk v0.0.0-20171031020902-cc8892cb2b05/go.mod h1:0N5CbwYI/8V1T6YOEwkgMvLmiGDNn661vLutBZQrC2c=
-github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20170925032315-6fe16293d6b7 h1:uHceyjNJ6fFv1Vv2zOrB7Qm8VnVjQ/TuJ8mwV7pHPKk=
-github.com/aliyun/aliyun-oss-go-sdk v0.0.0-20170925032315-6fe16293d6b7/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
+github.com/aliyun/aliyun-oss-go-sdk v2.1.0+incompatible h1:90Z2Cp7EqcbaYfVwVjmQoK8kgoFPz+doQlujcwe1BRg=
+github.com/aliyun/aliyun-oss-go-sdk v2.1.0+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/aws/aws-sdk-go v1.12.10 h1:ihg0UOujHVcFciyc6zs/q5VLhoG1K+oDLqgpCxkAh04=
 github.com/aws/aws-sdk-go v1.12.10/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/baidubce/bce-sdk-go v0.0.0-20180401121131-aa0c7bd66b01 h1:pmQ6WjFOHtNL0IHsLB0r3fOyRQ6KK/CfZ9dDI7ugZnU=
@@ -196,6 +196,7 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuArfcOvC4AoJmILihzhDg=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/object/cos.go
+++ b/object/cos.go
@@ -137,7 +137,12 @@ func (c *COS) List(prefix, marker string, limit int64) ([]*Object, error) {
 	}
 	objs := make([]*Object, len(out.Contents))
 	for i, item := range out.Contents {
-		objs[i] = &Object{item.Key, item.Size, item.LastModified, strings.HasSuffix(item.Key, "/")}
+		objs[i] = &Object{
+			item.Key,
+			item.Size,
+			item.LastModified,
+			strings.HasSuffix(item.Key, "/"),
+		}
 	}
 	return objs, nil
 }

--- a/object/mss.go
+++ b/object/mss.go
@@ -108,7 +108,12 @@ func (c *mss) List(prefix, marker string, limit int64) ([]*Object, error) {
 	}
 	objs := make([]*Object, len(out.Contents))
 	for i, item := range out.Contents {
-		objs[i] = &Object{item.Key, item.Size, item.LastModified, strings.HasSuffix(item.Key, "/")}
+		objs[i] = &Object{
+			item.Key,
+			item.Size,
+			item.LastModified,
+			strings.HasSuffix(item.Key, "/"),
+		}
 	}
 	return objs, nil
 }

--- a/object/object_storage.go
+++ b/object/object_storage.go
@@ -41,9 +41,9 @@ type PendingPart struct {
 
 type ObjectStorage interface {
 	String() string
+	Head(key string) (*Object, error)
 	Get(key string, off, limit int64) (io.ReadCloser, error)
 	Put(key string, in io.Reader) error
-	Exists(key string) error
 	Delete(key string) error
 	List(prefix, marker string, limit int64) ([]*Object, error)
 	ListAll(prefix, marker string) (<-chan *Object, error)

--- a/object/object_storage_test.go
+++ b/object/object_storage_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func get(s ObjectStorage, k string, off, limit int64) (string, error) {
-	r, err := s.Get("/test", off, limit)
+	r, err := s.Get(k, off, limit)
 	if err != nil {
 		return "", err
 	}
@@ -23,7 +23,7 @@ func get(s ObjectStorage, k string, off, limit int64) (string, error) {
 }
 
 func listAll(s ObjectStorage, prefix, marker string, limit int64) ([]*Object, error) {
-	r, err := s.List(prefix, marker, 100)
+	r, err := s.List(prefix, marker, limit)
 	if err == nil {
 		return r, nil
 	}
@@ -103,13 +103,13 @@ func testStorage(t *testing.T, s ObjectStorage) {
 	defer f.Close()
 	if err := s.Put("/file", f); err != nil {
 		t.Fatalf("failed to put from file")
-	} else if s.Exists("/file") != nil {
+	} else if _, err := s.Head("/file"); err != nil {
 		t.Fatalf("/file should exists")
 	} else {
 		s.Delete("/file")
 	}
 
-	if err := s.Exists("/test"); err != nil {
+	if _, err := s.Head("/test"); err != nil {
 		t.Fatalf("check exists failed: %s", err.Error())
 	}
 

--- a/object/prefix.go
+++ b/object/prefix.go
@@ -23,16 +23,21 @@ func (p *withPrefix) String() string {
 	return fmt.Sprintf("%s/%s", p.os, p.prefix)
 }
 
+func (p *withPrefix) Head(key string) (*Object, error) {
+	obj, err := p.os.Head(p.prefix + key)
+	if err != nil {
+		return nil, err
+	}
+	obj.Key = obj.Key[len(p.prefix):]
+	return obj, nil
+}
+
 func (p *withPrefix) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	return p.os.Get(p.prefix+key, off, limit)
 }
 
 func (p *withPrefix) Put(key string, in io.Reader) error {
 	return p.os.Put(p.prefix+key, in)
-}
-
-func (p *withPrefix) Exists(key string) error {
-	return p.os.Exists(p.prefix + key)
 }
 
 func (p *withPrefix) Delete(key string) error {

--- a/object/qiniu.go
+++ b/object/qiniu.go
@@ -59,6 +59,21 @@ func (q *qiniu) download(key string, off, limit int64) (io.ReadCloser, error) {
 	return resp.Body, nil
 }
 
+func (q *qiniu) Head(key string) (*Object, error) {
+	r, err := q.bm.Stat(q.bucket, key)
+	if err != nil {
+		return nil, err
+	}
+
+	mtime := time.Unix(0, r.PutTime*100)
+	return &Object{
+		key,
+		r.Fsize,
+		mtime,
+		strings.HasSuffix(key, "/"),
+	}, nil
+}
+
 func (q *qiniu) Get(key string, off, limit int64) (io.ReadCloser, error) {
 	// S3 SDK cannot get objects with prefix "/" in the key
 	if strings.HasPrefix(key, "/") && os.Getenv("QINIU_DOMAIN") != "" {
@@ -88,13 +103,8 @@ func (q *qiniu) CreateMultipartUpload(key string) (*MultipartUpload, error) {
 	return nil, notSupported
 }
 
-func (q *qiniu) Exists(key string) error {
-	_, err := q.bm.Stat(q.bucket, key)
-	return err
-}
-
 func (q *qiniu) Delete(key string) error {
-	if err := q.Exists(key); err != nil {
+	if _, err := q.Head(key); err != nil {
 		return err
 	}
 	return q.bm.Delete(q.bucket, key)
@@ -121,7 +131,12 @@ func (q *qiniu) List(prefix, marker string, limit int64) ([]*Object, error) {
 	for i := 0; i < n; i++ {
 		entry := entries[i]
 		if entry.Key > prefix {
-			objs = append(objs, &Object{entry.Key, entry.Fsize, time.Unix(entry.PutTime/10000000, 0), strings.HasSuffix(entry.Key, "/")})
+			objs = append(objs, &Object{
+				entry.Key,
+				entry.Fsize,
+				time.Unix(entry.PutTime/10000000, 0),
+				strings.HasSuffix(entry.Key, "/"),
+			})
 		}
 	}
 	return objs, nil

--- a/object/qiniu.go
+++ b/object/qiniu.go
@@ -134,7 +134,7 @@ func (q *qiniu) List(prefix, marker string, limit int64) ([]*Object, error) {
 			objs = append(objs, &Object{
 				entry.Key,
 				entry.Fsize,
-				time.Unix(entry.PutTime/10000000, 0),
+				time.Unix(0, entry.PutTime * 100),
 				strings.HasSuffix(entry.Key, "/"),
 			})
 		}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -43,32 +43,55 @@ var (
 var logger = utils.GetLogger("juicesync")
 
 // iterate on all the keys that starts at marker from object storage.
-func iterate(store object.ObjectStorage, marker, end string) (<-chan *object.Object, error) {
-	start := time.Now()
-	logger.Debugf("Listing objects from %s marker %q", store, marker)
-	if ch, err := store.ListAll("", marker); err == nil {
-		if end == "" {
-			return ch, err
+func iterate(store object.ObjectStorage, start, end string) (<-chan *object.Object, error) {
+	startTime := time.Now()
+	logger.Debugf("Iterating objects from %s start %q", store, start)
+
+	out := make(chan *object.Object, maxResults)
+
+	// As the result of object storage's List method doesn't include the marker key,
+	// we try List the marker key separately.
+	if start != "" {
+		if obj, err := store.Head(start); err == nil {
+			logger.Debugf("Found start key: %s from %s in %s", start, store, time.Now().Sub(startTime))
+			out <- obj
 		}
-		ch2 := make(chan *object.Object)
+	}
+
+	if ch, err := store.ListAll("", start); err == nil {
+		if end == "" {
+			go func() {
+				for obj := range ch {
+					if obj == nil {
+						break
+					}
+					out <- obj
+				}
+				close(out)
+			}()
+			return out, nil
+		}
+
 		go func() {
-			for o := range ch {
-				if o == nil || o.Key >= end {
+			for obj := range ch {
+				if obj == nil || obj.Key > end {
 					break
 				}
-				ch2 <- o
+				out <- obj
 			}
-			close(ch2)
+			close(out)
 		}()
-		return ch2, nil
+		return out, nil
 	}
+
+	marker := start
+	logger.Debugf("Listing objects from %s marker %q", store, marker)
 	objs, err := store.List("", marker, maxResults)
 	if err != nil {
 		logger.Errorf("Can't list %s: %s", store, err.Error())
 		return nil, err
 	}
-	logger.Debugf("Found %d object from %s in %s", len(objs), store, time.Now().Sub(start))
-	out := make(chan *object.Object, maxResults)
+	logger.Debugf("Found %d object from %s in %s", len(objs), store, time.Now().Sub(startTime))
 	go func() {
 		lastkey := ""
 		first := true
@@ -79,10 +102,11 @@ func iterate(store object.ObjectStorage, marker, end string) (<-chan *object.Obj
 				if !first && key <= lastkey {
 					logger.Fatalf("The keys are out of order: marker %q, last %q current %q", marker, lastkey, key)
 				}
-				if end != "" && key >= end {
+				if end != "" && key > end {
 					break END
 				}
 				lastkey = key
+				logger.Debugf("key: %s", key)
 				out <- obj
 				first = false
 			}
@@ -93,7 +117,7 @@ func iterate(store object.ObjectStorage, marker, end string) (<-chan *object.Obj
 			}
 
 			marker = lastkey
-			start = time.Now()
+			startTime = time.Now()
 			logger.Debugf("Continue listing objects from %s marker %q", store, marker)
 			objs, err = store.List("", marker, maxResults)
 			for err != nil {
@@ -102,7 +126,7 @@ func iterate(store object.ObjectStorage, marker, end string) (<-chan *object.Obj
 				time.Sleep(time.Millisecond * 100)
 				objs, err = store.List("", marker, maxResults)
 			}
-			logger.Debugf("Found %d object from %s in %s", len(objs), store, time.Now().Sub(start))
+			logger.Debugf("Found %d object from %s in %s", len(objs), store, time.Now().Sub(startTime))
 			if err != nil {
 				// Telling that the listing has failed
 				out <- nil
@@ -124,7 +148,7 @@ func copyObject(src, dst object.ObjectStorage, obj *object.Object) error {
 	if strings.HasPrefix(src.String(), "file://") || strings.HasPrefix(dst.String(), "file://") {
 		in, e := src.Get(key, 0, -1)
 		if e != nil {
-			if src.Exists(key) != nil {
+			if _, err := src.Head(key); err != nil {
 				return nil
 			}
 			return e
@@ -138,7 +162,7 @@ func copyObject(src, dst object.ObjectStorage, obj *object.Object) error {
 	}
 	in, e := src.Get(key, 0, int64(firstBlock))
 	if e != nil {
-		if src.Exists(key) != nil {
+		if _, err := src.Head(key); err != nil {
 			return nil
 		}
 		return e
@@ -377,8 +401,9 @@ OUT:
 		for hasMore && (dstobj == nil || obj.Key > dstobj.Key) {
 			var ok bool
 			if config.DeleteDst && dstobj != nil && dstobj.Key < obj.Key {
-				if !config.Dirs && dstobj.Size == 0 && strings.HasSuffix(dstobj.Key, "/") {
+				if !config.Dirs && dstobj.IsDir {
 					// ignore
+					logger.Debug("Ignore deleting dst directory ", dstobj.Key)
 				} else {
 					dstobj.Size = markDelete
 					todo <- dstobj

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -62,9 +62,6 @@ func iterate(store object.ObjectStorage, start, end string) (<-chan *object.Obje
 		if end == "" {
 			go func() {
 				for obj := range ch {
-					if obj == nil {
-						break
-					}
 					out <- obj
 				}
 				close(out)
@@ -74,7 +71,7 @@ func iterate(store object.ObjectStorage, start, end string) (<-chan *object.Obje
 
 		go func() {
 			for obj := range ch {
-				if obj == nil || obj.Key > end {
+				if obj != nil && obj.Key > end {
 					break
 				}
 				out <- obj

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -25,13 +25,13 @@ func TestIterator(t *testing.T) {
 	m.Put("aa", bytes.NewReader([]byte("a")))
 	m.Put("c", bytes.NewReader([]byte("a")))
 
-	ch, _ := iterate(m, "a", "c")
+	ch, _ := iterate(m, "a", "b")
 	keys := collectAll(ch)
-	if len(keys) != 2 {
-		t.Errorf("length should be 2, but got %d", len(keys))
+	if len(keys) != 3 {
+		t.Errorf("length should be 3, but got %d", len(keys))
 		t.FailNow()
 	}
-	if !reflect.DeepEqual(keys, []string{"aa", "b"}) {
+	if !reflect.DeepEqual(keys, []string{"a", "aa", "b"}) {
 		t.Errorf("result wrong: %s", keys)
 		t.FailNow()
 	}


### PR DESCRIPTION
1. Add `Head` method for `ObjectStorage` and remove `Exists` method. The `Exists` method can be replaced like this:
```go
err := store.Exists(key)  ==>  _, err := store.Head(key)
```
2. Modify `ListAll` method's behavior for `sftp` and `file`.
    To make `sftp` and `file` consistent with **Object Storage** , if the `prefix` is ends with `/` , `prefix` is the start point to traverse, otherwise the `filepath.Dir(prefix)` would be listed for the case like this:
```
temp
├── x
│   └── y
│       └── z.txt
├── xy
├── xy.txt
└── xyz
    └── xyz.txt
```
where the `prefix` is `./temp/x` .