### PR TITLE
add unit-test for file:// and sftp://

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 juicesync
 .idea
+.DS_Store

--- a/object/filesystem_test.go
+++ b/object/filesystem_test.go
@@ -1,0 +1,149 @@
+package object
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func testKeysEqual(objs []*Object, expectedKeys []string) error {
+	gottenKeys := make([]string, len(objs))
+	for idx, obj := range objs {
+		gottenKeys[idx] = obj.Key
+	}
+	if len(gottenKeys) != len(expectedKeys) {
+		return fmt.Errorf("Expected {%s}, got {%s}", strings.Join(expectedKeys, ", "),
+			strings.Join(gottenKeys, ", "))
+	}
+
+	for idx, key := range gottenKeys {
+		if key != expectedKeys[idx] {
+			return fmt.Errorf("Expected {%s}, got {%s}", strings.Join(expectedKeys, ", "),
+				strings.Join(gottenKeys, ", "))
+		}
+	}
+	return nil
+}
+
+func TestFsFile(t *testing.T) {
+	keys := []string{
+		"x/",
+		"x/x.txt",
+		"xy.txt",
+		"xyz/",
+		"xyz/xyz.txt",
+	}
+	s0 := newDisk("/tmp/abc/unit-test/", "", "")
+	// initialize directory tree
+	for _, key := range keys {
+		if err := s0.Put(key, bytes.NewReader([]byte{})); err != nil {
+			t.Fatalf("PUT object `%s` failed: %q", key, err)
+		}
+	}
+	// cleanup
+	defer func() {
+		// delete reversely, directory only can be deleted when it's empty
+		idx := len(keys) - 1
+		for ; idx >= 0; idx-- {
+			if err := s0.Delete(keys[idx]); err != nil {
+				t.Fatalf("DELETE object `%s` failed: %q", keys[idx], err)
+			}
+		}
+	}()
+
+	s := newDisk("/tmp/abc/unit-test/x/", "", "")
+	objs, err := listAll(s, "", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys := []string{"", "x.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+
+	s = newDisk("/tmp/abc/unit-test/x", "", "")
+	objs, err = listAll(s, "", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys = []string{"/", "/x.txt", "y.txt", "yz/", "yz/xyz.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+
+	s = newDisk("/tmp/abc/unit-test/xy", "", "")
+	objs, err = listAll(s, "", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys = []string{".txt", "z/", "z/xyz.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+}
+
+func TestFsSftp(t *testing.T) {
+	// utils.SetLogLevel(logrus.DebugLevel)
+	sftpHost := os.Getenv("SFTP_HOST")
+	if sftpHost == "" {
+		t.SkipNow()
+	}
+	sftpUser, sftpPass := os.Getenv("SFTP_USER"), os.Getenv("SFTP_PASS")
+	s0 := newSftp(sftpHost, sftpUser, sftpPass)
+
+	keys := []string{
+		"x/",
+		"x/x.txt",
+		"xy.txt",
+		"xyz/",
+		"xyz/xyz.txt",
+	}
+	// initialize directory tree
+	for _, key := range keys {
+		if err := s0.Put(key, bytes.NewReader([]byte{})); err != nil {
+			t.Fatalf("PUT object `%s` failed: %q", key, err)
+		}
+	}
+	// cleanup
+	defer func() {
+		// delete reversely, directory only can be deleted when it's empty
+		idx := len(keys) - 1
+		for ; idx >= 0; idx-- {
+			if err := s0.Delete(keys[idx]); err != nil {
+				t.Fatalf("DELETE object `%s` failed: %q", keys[idx], err)
+			}
+		}
+	}()
+
+	s := newSftp(sftpHost+"x/", sftpUser, sftpPass)
+	objs, err := listAll(s, "", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys := []string{"", "x.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+
+	s = newSftp(sftpHost+"x", sftpUser, sftpPass)
+	objs, err = listAll(s, "", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys = []string{"/", "/x.txt", "y.txt", "yz/", "yz/xyz.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+
+	s = newSftp(sftpHost+"xy", sftpUser, sftpPass)
+	objs, err = listAll(s, "", "", 100)
+	if err != nil {
+		t.Fatalf("list failed: %s", err)
+	}
+	expectedKeys = []string{".txt", "z/", "z/xyz.txt"}
+	if err = testKeysEqual(objs, expectedKeys); err != nil {
+		t.Fatalf("testKeysEqual fail: %s", err)
+	}
+}

--- a/object/object_storage_test.go
+++ b/object/object_storage_test.go
@@ -66,7 +66,6 @@ func testStorage(t *testing.T, s ObjectStorage) {
 		t.Fatalf("expect ll, but got %v, error:%s", d, e)
 	}
 	if d, e := get(s, "/test", 4, 2); d != "o" {
-		// OSS fail
 		t.Errorf("out-of-range get: 'o', but got %v, error:%s", len(d), e)
 	}
 


### PR DESCRIPTION
- Add unit test for `ListAll` method of `file://` and `sftp://` storage.
- Unify the behavior of `sftp://` and `file://` .