### PR TITLE
Auto find endpoint for alicloud oss

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ Note:
 - S3: The access key and secret key for S3 could be provided by AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or IAM role.
 - COS: The AppID should be part of the bucket name.
 - GCS: The machine should be authorized to access Google Cloud Storage.
-- OSS: The credential can be provided by RAM role.
+- OSS:
+  The credential can be provided by environment variable `ALICLOUD_ACCESS_KEY_ID` and `ALICLOUD_ACCESS_KEY_SECRET` , RAM role, [EMR MetaService](https://help.aliyun.com/document_detail/43966.html).
+  The command line argument support `oss://[ACCESS_KEY:SECRET_KEY@]BUCKET[/PREFIX]` , the credential must have `oss:ListBuckets` permission.
 - Qiniu:
   The S3 endpoint should be used for Qiniu, for example, abc.cn-north-1-s3.qiniu.com.
   If there are keys starting with "/", the domain should be provided as QINIU_DOMAIN.

--- a/object/object_storage_test.go
+++ b/object/object_storage_test.go
@@ -204,11 +204,15 @@ func TestS3(t *testing.T) {
 }
 
 func TestOSS(t *testing.T) {
-	if os.Getenv("OSS_ACCESS_KEY") == "" {
+	if os.Getenv("ALICLOUD_ACCESS_KEY_ID") == "" {
 		t.SkipNow()
 	}
-	s := newOSS("https://test.oss-us-west-1.aliyuncs.com",
-		os.Getenv("OSS_ACCESS_KEY"), os.Getenv("OSS_SECRET_KEY"))
+	bucketName := "test"
+	if b := os.Getenv("OSS_TEST_BUCKET"); b != "" {
+		bucketName = b
+	}
+	s := newOSS(fmt.Sprintf("https://%s", bucketName),
+		os.Getenv("ALICLOUD_ACCESS_KEY_ID"), os.Getenv("ALICLOUD_ACCESS_KEY_SECRET"))
 	testStorage(t, s)
 }
 


### PR DESCRIPTION
1. **OSS** : add support `oss://[ACCESS_KEY:SECRET_KEY@]<BUCKET>` ，the credential must have `oss:ListBuckets` permission.
2. **OSS**: add support  using environment variable `ALICLOUD_ACCESS_KEY_ID` and `ALICLOUD_ACCESS_KEY_SECRET` or [EMR MetaService](https://help.aliyun.com/document_detail/43966.html) for credential.