### PR TITLE
fix s3 auto find region

### DIFF
--- a/object/s3.go
+++ b/object/s3.go
@@ -245,8 +245,8 @@ func autoS3Region(bucketName, accessKey, secretKey string) (string, error) {
 			return *result.LocationConstraint, nil
 		}
 		if err1, ok := err.(awserr.Error); ok {
-			// InvalidAccessKeyId means the credentials is not for this region
-			if err1.Code() != "InvalidAccessKeyId" {
+			// continue to try other regions if the credentials are invalid, otherwise stop trying.
+			if errCode := err1.Code(); errCode != "InvalidAccessKeyId" && errCode != "InvalidToken" {
 				return "", err
 			}
 		}


### PR DESCRIPTION
When the credentials not match the region, the `InvalidToken` error code may be returned. This happened when running `juicesync` at **EC2** instance  in `cn-northwest-1` region using *IAM* role to access **S3** .