### PR TITLE
Add command option --force-update(-f) to support always overwriting existed files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,37 +5,39 @@ import (
 )
 
 type Config struct {
-	Start     string
-	End       string
-	Threads   int
-	HTTPPort  int
-	Update    bool
-	Perms     bool
-	Dry       bool
-	DeleteSrc bool
-	DeleteDst bool
-	Dirs      bool
-	Exclude   []string
-	Include   []string
-	Verbose   bool
-	Quiet     bool
+	Start       string
+	End         string
+	Threads     int
+	HTTPPort    int
+	Update      bool
+	ForceUpdate bool
+	Perms       bool
+	Dry         bool
+	DeleteSrc   bool
+	DeleteDst   bool
+	Dirs        bool
+	Exclude     []string
+	Include     []string
+	Verbose     bool
+	Quiet       bool
 }
 
 func NewConfigFromCli(c *cli.Context) *Config {
 	return &Config{
-		Start:     c.String("start"),
-		End:       c.String("end"),
-		Threads:   c.Int("threads"),
-		HTTPPort:  c.Int("http-port"),
-		Update:    c.Bool("update"),
-		Perms:     c.Bool("perms"),
-		Dirs:      c.Bool("dirs"),
-		Dry:       c.Bool("dry"),
-		DeleteSrc: c.Bool("delete-src"),
-		DeleteDst: c.Bool("delete-dst"),
-		Exclude:   c.StringSlice("exclude"),
-		Include:   c.StringSlice("include"),
-		Verbose:   c.Bool("verbose"),
-		Quiet:     c.Bool("quiet"),
+		Start:       c.String("start"),
+		End:         c.String("end"),
+		Threads:     c.Int("threads"),
+		HTTPPort:    c.Int("http-port"),
+		Update:      c.Bool("update"),
+		ForceUpdate: c.Bool("force-update"),
+		Perms:       c.Bool("perms"),
+		Dirs:        c.Bool("dirs"),
+		Dry:         c.Bool("dry"),
+		DeleteSrc:   c.Bool("delete-src"),
+		DeleteDst:   c.Bool("delete-dst"),
+		Exclude:     c.StringSlice("exclude"),
+		Include:     c.StringSlice("include"),
+		Verbose:     c.Bool("verbose"),
+		Quiet:       c.Bool("quiet"),
 	}
 }

--- a/main.go
+++ b/main.go
@@ -169,6 +169,11 @@ func main() {
 			Usage:   "update existing file if the source is newer",
 		},
 		&cli.BoolFlag{
+			Name:    "force-update",
+			Aliases: []string{"f"},
+			Usage:   "always update existing file",
+		},
+		&cli.BoolFlag{
 			Name:  "perms",
 			Usage: "preserve permissions",
 		},

--- a/object/mem.go
+++ b/object/mem.go
@@ -186,7 +186,7 @@ func (m *memStore) List(prefix, marker string, limit int64) ([]*Object, error) {
 }
 
 func newMem(endpoint, accesskey, secretkey string) ObjectStorage {
-	store := &memStore{}
+	store := &memStore{name: endpoint}
 	store.objects = make(map[string]*obj)
 	return store
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -418,7 +418,10 @@ OUT:
 		}
 		// FIXME: there is a race when source is modified during coping
 		if !hasMore || obj.Key < dstobj.Key ||
-			obj.Key == dstobj.Key && (obj.Size != dstobj.Size || config.Update && obj.Mtime.Unix() > dstobj.Mtime.Unix()) {
+			obj.Key == dstobj.Key && (
+				config.ForceUpdate ||
+				obj.Size != dstobj.Size ||
+				config.Update && obj.Mtime.Unix() > dstobj.Mtime.Unix()) {
 			todo <- obj
 			atomic.AddUint64(&missing, 1)
 		} else if config.DeleteSrc && dstobj != nil && obj.Key == dstobj.Key && obj.Size == dstobj.Size {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -418,9 +418,7 @@ OUT:
 		}
 		// FIXME: there is a race when source is modified during coping
 		if !hasMore || obj.Key < dstobj.Key ||
-			obj.Key == dstobj.Key && (
-				config.ForceUpdate ||
-				obj.Size != dstobj.Size ||
+			obj.Key == dstobj.Key && (config.ForceUpdate || obj.Size != dstobj.Size ||
 				config.Update && obj.Mtime.Unix() > dstobj.Mtime.Unix()) {
 			todo <- obj
 			atomic.AddUint64(&missing, 1)

--- a/versioninfo/versioninfo.go
+++ b/versioninfo/versioninfo.go
@@ -8,7 +8,7 @@ var (
 	REVISION     = "HEAD"
 	REVISIONDATE = "now"
 	USAGE        = `Usage: juicesync [options] SRC DST
-    SRC and DST should be [NAME://][ACCESS_KEY:SECRET_KEY@]BUCKET.ENDPOINT[/PREFIX]`
+    SRC and DST should be [NAME://][ACCESS_KEY:SECRET_KEY@]BUCKET[.ENDPOINT][/PREFIX]`
 )
 
 func Version() string {


### PR DESCRIPTION
With `--force-update`(`-f` for short) option, _juicesync_ will always copy file to destination, no matter whether the file exist or not.