### PR TITLE
Copy objects from multiple machines

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 	Dirs        bool
 	Exclude     []string
 	Include     []string
+	Manager     string
+	Workers     []string
 	Verbose     bool
 	Quiet       bool
 }
@@ -37,6 +39,8 @@ func NewConfigFromCli(c *cli.Context) *Config {
 		DeleteDst:   c.Bool("delete-dst"),
 		Exclude:     c.StringSlice("exclude"),
 		Include:     c.StringSlice("include"),
+		Workers:     c.StringSlice("worker"),
+		Manager:     c.String("manager"),
 		Verbose:     c.Bool("verbose"),
 		Quiet:       c.Bool("quiet"),
 	}

--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func main() {
 		},
 		&cli.StringSliceFlag{
 			Name:  "worker",
-			Usage: "a host to launch worker",
+			Usage: "hosts (seperated by comma) to launch worker",
 		},
 		&cli.BoolFlag{
 			Name:    "verbose",

--- a/main.go
+++ b/main.go
@@ -203,6 +203,14 @@ func main() {
 			Name:  "include",
 			Usage: "only include keys containing `PATTERN` (POSIX regular expressions)",
 		},
+		&cli.StringFlag{
+			Name:  "manager",
+			Usage: "manager address",
+		},
+		&cli.StringSliceFlag{
+			Name:  "worker",
+			Usage: "a host to launch worker",
+		},
 		&cli.BoolFlag{
 			Name:    "verbose",
 			Aliases: []string{"v"},

--- a/sync/cluster.go
+++ b/sync/cluster.go
@@ -1,0 +1,213 @@
+package sync
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/juicedata/juicesync/config"
+	"github.com/juicedata/juicesync/object"
+)
+
+type Stat struct {
+	Copied      int64
+	CopiedBytes int64
+	Failed      int64
+	Deleted     int64
+}
+
+func updateStats(r *Stat) {
+	atomic.AddInt64(&copied, r.Copied)
+	atomic.AddInt64(&copiedBytes, r.CopiedBytes)
+	atomic.AddInt64(&failed, r.Failed)
+	atomic.AddInt64(&deleted, r.Deleted)
+}
+
+func httpRequest(url string, body []byte) (ans []byte, err error) {
+	method := "GET"
+	if body != nil {
+		method = "POST"
+	}
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	var resp *http.Response
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return ioutil.ReadAll(resp.Body)
+}
+
+func sendStats(addr string) {
+	var r Stat
+	r.Copied = atomic.LoadInt64(&copied)
+	r.CopiedBytes = atomic.LoadInt64(&copiedBytes)
+	r.Failed = atomic.LoadInt64(&failed)
+	r.Deleted = atomic.LoadInt64(&deleted)
+	d, _ := json.Marshal(r)
+	ans, err := httpRequest(fmt.Sprintf("http://%s/stats", addr), d)
+	if err != nil || string(ans) != "OK" {
+		logger.Errorf("update stats: %s %s", string(ans), err)
+	} else {
+		atomic.AddInt64(&copied, -r.Copied)
+		atomic.AddInt64(&copiedBytes, -r.CopiedBytes)
+		atomic.AddInt64(&failed, -r.Failed)
+		atomic.AddInt64(&deleted, -r.Deleted)
+	}
+}
+
+func startManager(tasks chan *object.Object) string {
+	http.HandleFunc("/fetch", func(w http.ResponseWriter, req *http.Request) {
+		var objs []*object.Object
+		obj, ok := <-tasks
+		if !ok {
+			w.Write([]byte("[]"))
+			return
+		}
+		objs = append(objs, obj)
+	LOOP:
+		for {
+			select {
+			case obj = <-tasks:
+				if obj == nil {
+					break LOOP
+				}
+				objs = append(objs, obj)
+				if len(objs) > 100 {
+					break LOOP
+				}
+			default:
+				break LOOP
+			}
+		}
+		d, err := json.MarshalIndent(objs, "", "  ")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		logger.Infof("send %d objects to %s", len(objs), req.RemoteAddr)
+		w.Write(d)
+	})
+	http.HandleFunc("/stats", func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != "POST" {
+			http.Error(w, "POST required", http.StatusBadRequest)
+			return
+		}
+		d, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			logger.Errorf("read: %s", err)
+			return
+		}
+		var r Stat
+		err = json.Unmarshal(d, &r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		updateStats(&r)
+		w.Write([]byte("OK"))
+	})
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		logger.Fatalf("listen: %s", err)
+	}
+	logger.Infof("Listen at %s", l.Addr())
+	go http.Serve(l, nil)
+	return l.Addr().String()
+}
+
+func findSelfPath() string {
+	program := os.Args[0]
+	if strings.Contains(program, "/") {
+		path, err := filepath.Abs(program)
+		if err != nil {
+			logger.Fatalf("resolve path %s: %s", program, err)
+		}
+		return path
+	}
+	for _, searchPath := range strings.Split(os.Getenv("PATH"), ":") {
+		if searchPath != "" {
+			p := filepath.Join(searchPath, program)
+			if _, err := os.Stat(p); err == nil {
+				return p
+			}
+		}
+	}
+	logger.Fatalf("can't find path for %s", program)
+	panic("")
+}
+
+func launchWorker(address string, config *config.Config, wg *sync.WaitGroup) {
+	for _, host := range config.Workers {
+		wg.Add(1)
+		go func(host string) {
+			defer wg.Done()
+			// copy
+			path := findSelfPath()
+			rpath := "/tmp/juicesync"
+			cmd := exec.Command("rsync", "-au", path, host+":"+rpath)
+			err := cmd.Run()
+			if err != nil {
+				logger.Errorf("copy to %s: %s", host, err)
+				return
+			}
+			// launch juicesync
+			var args = []string{"ssh", host}
+			args = append(args, os.Args...)
+			args[2] = rpath
+			args = append(args, "-manager")
+			args = append(args, address)
+			cmd = exec.Command("juicesync")
+			err = cmd.Start()
+			if err != nil {
+				logger.Errorf("start juicesync at %s: %s", host, err)
+				return
+			}
+			err = cmd.Wait()
+			if err != nil {
+				logger.Errorf("%s: %s", host, err)
+			}
+		}(host)
+	}
+}
+
+func fetchJobs(todo chan *object.Object, config *config.Config) {
+	for {
+		// fetch jobs
+		url := fmt.Sprintf("http://%s/fetch", config.Manager)
+		ans, err := httpRequest(url, nil)
+		if err != nil {
+			logger.Errorf("fetch jobs: %s", err)
+			time.Sleep(time.Second)
+			continue
+		}
+		var jobs []*object.Object
+		err = json.Unmarshal(ans, &jobs)
+		if err != nil {
+			logger.Errorf("Unmarshal %s: %s", string(ans), err)
+			time.Sleep(time.Second)
+			continue
+		}
+		logger.Infof("got %d jobs", len(jobs))
+		if len(jobs) == 0 {
+			break
+		}
+		for _, obj := range jobs {
+			todo <- obj
+		}
+	}
+	close(todo)
+}

--- a/sync/cluster.go
+++ b/sync/cluster.go
@@ -214,7 +214,6 @@ func launchWorker(address string, config *config.Config, wg *sync.WaitGroup) {
 			var args = []string{host, rpath, "-manager", address}
 			args = append(args, os.Args[1:]...)
 			cmd = exec.Command("ssh", args...)
-			logger.Info(strings.Join(args, " "))
 			stderr, err := cmd.StderrPipe()
 			if err != nil {
 				logger.Errorf("redirect stderr: %s", err)

--- a/sync/cluster.go
+++ b/sync/cluster.go
@@ -197,7 +197,8 @@ func findSelfPath() string {
 }
 
 func launchWorker(address string, config *config.Config, wg *sync.WaitGroup) {
-	for _, host := range config.Workers {
+	workers := strings.Split(strings.Join(config.Workers, ","), ",")
+	for _, host := range workers {
 		wg.Add(1)
 		go func(host string) {
 			defer wg.Done()
@@ -228,10 +229,10 @@ func launchWorker(address string, config *config.Config, wg *sync.WaitGroup) {
 				r := bufio.NewReader(stderr)
 				for {
 					line, err := r.ReadString('\n')
-					if err != nil {
+					if err != nil || len(line) == 0 {
 						return
 					}
-					println(host, line)
+					println(host, line[:len(line)-1])
 				}
 			}()
 			err = cmd.Wait()

--- a/sync/cluster_test.go
+++ b/sync/cluster_test.go
@@ -1,0 +1,31 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/juicedata/juicesync/config"
+	"github.com/juicedata/juicesync/object"
+)
+
+func TestCluster(t *testing.T) {
+	// manager
+	todo := make(chan *object.Object, 100)
+	addr := startManager(todo)
+	sendStats(addr)
+	// worker
+	var conf config.Config
+	conf.Manager = addr
+	mytodo := make(chan *object.Object, 100)
+	go fetchJobs(mytodo, &conf)
+
+	todo <- &object.Object{Key: "test"}
+	close(todo)
+
+	obj := <-mytodo
+	if obj.Key != "test" {
+		t.Fatalf("expect test but got %s", obj.Key)
+	}
+	if _, ok := <-mytodo; ok {
+		t.Fatalf("should end")
+	}
+}


### PR DESCRIPTION
Given a list of machines (ssh without password), juicesync can copy itself and launch as a work in them, from example:

```
$ ./juicesync --worker node1,node2  bucket1/  bucket3/
```
