### PR TITLE
fix: reorder options and add the linux makefile item

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,8 @@ juicesync:
 juicesync.exe: *.go utils/*.go versioninfo/*.go
 	GOOS=windows go build -ldflags="$(LDFLAGS)" -buildmode exe -o juicesync.exe
 
+juicesync.linux:
+	GOOS=linux GOARCH=amd64 go build -ldflags="$(LDFLAGS)" -o juicesync
+
 test:
 	go test ./...

--- a/main.go
+++ b/main.go
@@ -194,6 +194,77 @@ func run(c *cli.Context) error {
 	return sync.Sync(src, dst, config)
 }
 
+func isFlag(flags []cli.Flag, option string) (bool, bool) {
+	if !strings.HasPrefix(option, "-") {
+		return false, false
+	}
+	// --V or -v work the same
+	option = strings.TrimLeft(option, "-")
+	for _, flag := range flags {
+		_, isBool := flag.(*cli.BoolFlag)
+		for _, name := range flag.Names() {
+			if option == name || strings.HasPrefix(option, name+"=") {
+				return true, !isBool && !strings.Contains(option, "=")
+			}
+		}
+	}
+	return false, false
+}
+
+func reorderOptions(app *cli.App, args []string) []string {
+	var newArgs = []string{args[0]}
+	var others []string
+	globalFlags := append(app.Flags, cli.VersionFlag)
+	for i := 1; i < len(args); i++ {
+		option := args[i]
+		if ok, hasValue := isFlag(globalFlags, option); ok {
+			newArgs = append(newArgs, option)
+			if hasValue {
+				i++
+				newArgs = append(newArgs, args[i])
+			}
+		} else {
+			others = append(others, option)
+		}
+	}
+	// no command
+	if len(others) == 0 {
+		return newArgs
+	}
+	cmdName := others[0]
+	var cmd *cli.Command
+	for _, c := range app.Commands {
+		if c.Name == cmdName {
+			cmd = c
+		}
+	}
+	if cmd == nil {
+		// can't recognize the command, skip it
+		return append(newArgs, others...)
+	}
+
+	newArgs = append(newArgs, cmdName)
+	args, others = others[1:], nil
+	// -h is valid for all the commands
+	cmdFlags := append(cmd.Flags, cli.HelpFlag)
+	for i := 0; i < len(args); i++ {
+		option := args[i]
+		if ok, hasValue := isFlag(cmdFlags, option); ok {
+			newArgs = append(newArgs, option)
+			if hasValue && len(args[i+1:]) > 0 {
+				i++
+				newArgs = append(newArgs, args[i])
+			}
+		} else {
+			if strings.HasPrefix(option, "-") && !utils.StringContains(args, "--generate-bash-completion") {
+				logger.Fatalf("unknown option: %s", option)
+			}
+			others = append(others, option)
+		}
+	}
+	return append(newArgs, others...)
+}
+
 func main() {
 	cli.VersionFlag = &cli.BoolFlag{
 		Name: "version", Aliases: []string{"V"},
@@ -360,7 +431,7 @@ func main() {
 		return run(c)
 	}
 
-	err := app.Run(os.Args)
+	err := app.Run(reorderOptions(app, os.Args))
 	if err != nil {
 		logger.Fatalf("Error running juicesync: %s", err)
 	}


### PR DESCRIPTION
```
$ juicesync oss://ak:sk@zhijian-test2.oss-cn-hangzhou-internal.aliyuncs.com/ /tmp/test1/ -q
2022/12/19 20:43:34.181055 juicesync[22121] <ERROR>: juicesync [options] SRC DST
    SRC and DST should be [NAME://][ACCESS_KEY:SECRET_KEY@]BUCKET[.ENDPOINT][/PREFIX] [main.go:357]
```

close #127  #134