### PR TITLE
pick the fixes for juicesync main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/juicedata/juicesync
 go 1.18
 
 require (
+	github.com/erikdubbelboer/gspt v0.0.0-20210805194459-ce36a5128377
 	github.com/juicedata/juicefs v1.0.4
 	github.com/sirupsen/logrus v1.9.0
 	github.com/urfave/cli/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/erikdubbelboer/gspt v0.0.0-20210805194459-ce36a5128377 h1:gT+RM6gdTIAzMT7HUvmT5mL8SyG8Wx7iS3+L0V34Km4=
+github.com/erikdubbelboer/gspt v0.0.0-20210805194459-ce36a5128377/go.mod h1:v6o7m/E9bfvm79dE1iFiF+3T7zLBnrjYjkWMa1J+Hv0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/main.go
+++ b/main.go
@@ -178,8 +178,16 @@ func run(c *cli.Context) error {
 	utils.InitLoggers(false)
 
 	// Windows support `\` and `/` as its separator, Unix only use `/`
-	srcURL := strings.Replace(c.Args().Get(0), "\\", "/", -1)
-	dstURL := strings.Replace(c.Args().Get(1), "\\", "/", -1)
+	srcURL := c.Args().Get(0)
+	dstURL := c.Args().Get(1)
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(srcURL, "://") {
+			srcURL = strings.Replace(srcURL, "\\", "/", -1)
+		}
+		if !strings.Contains(dstURL, "://") {
+			dstURL = strings.Replace(dstURL, "\\", "/", -1)
+		}
+	}
 	if strings.HasSuffix(srcURL, "/") != strings.HasSuffix(dstURL, "/") {
 		logger.Fatalf("SRC and DST should both end with path separator or not!")
 	}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/erikdubbelboer/gspt"
 	"github.com/juicedata/juicefs/pkg/object"
 	"github.com/juicedata/juicefs/pkg/sync"
 	"github.com/juicedata/juicefs/pkg/utils"
@@ -180,6 +181,8 @@ func run(c *cli.Context) error {
 	// Windows support `\` and `/` as its separator, Unix only use `/`
 	srcURL := c.Args().Get(0)
 	dstURL := c.Args().Get(1)
+	removePassword(srcURL)
+	removePassword(dstURL)
 	if runtime.GOOS == "windows" {
 		if !strings.Contains(srcURL, "://") {
 			srcURL = strings.Replace(srcURL, "\\", "/", -1)
@@ -200,6 +203,19 @@ func run(c *cli.Context) error {
 		return err
 	}
 	return sync.Sync(src, dst, config)
+}
+
+func removePassword(uri string) {
+	uri2 := utils.RemovePassword(uri)
+	if uri2 != uri {
+		for i, a := range os.Args {
+			if a == uri {
+				os.Args[i] = uri2
+				break
+			}
+		}
+	}
+	gspt.SetProcTitle(strings.Join(os.Args, " "))
 }
 
 func isFlag(flags []cli.Flag, option string) (bool, bool) {


### PR DESCRIPTION
We forgot to pick the fixes for juicesync main routine:
- https://github.com/juicedata/juicefs/pull/2778 (merged in juicefs v1.0.2)
- https://github.com/juicedata/juicefs/pull/3256 (merged in juicefs v1.0.4)

Better have them in the next release.